### PR TITLE
[CDU] Fix error message deletes input, add support for input delay (#…

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,11 +5,11 @@
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
 ## 0.5.0
-1. [MCDU] Added Perf Page CI functionality - @MisterChocker (Leon)
-1. [MCDU] Added PROG Page CRZ FL functionality and logic - @MisterChocker (Leon)
-1. [MCDU] Added Init B page only available until engine start - @MisterChocker (Leon)
-1. [MCDU] Added mcdu page id system - @MisterChocker (Leon)
-1. [MCDU] Added Progress Page REC MAX FL functionality and dummy OPT - @MisterChocker (Leon)
+1. [CDU] Added Performance Page CI functionality - @MisterChocker (Leon)
+1. [CDU] Added Progress Page CRZ FL functionality and logic - @MisterChocker (Leon)
+1. [CDU] Added Init B page only available until engine start - @MisterChocker (Leon)
+1. [CDU] Added mcdu page id system - @MisterChocker (Leon)
+1. [CDU] Added Progress Page REC MAX FL functionality and dummy OPT - @MisterChocker (Leon)
 1. [PFD] Added proper altitude constrain visuals - @MisterChocker (Leon)
 1. [COLORS] Improved MCDU/PFD/ND/ECAM colors - @MisterChocker (Leon)
 1. [PFD] General improvements to the display layout - @MisterChocker (Leon)
@@ -62,6 +62,8 @@
 1. [TEXTURES] upgraded to 4k Textures (pedestal,throttle unit) fixed decal texture - @Pleasure0102 (Pleasure)
 1. [PFD] Added FMAs ALT CST and ALT CST* as well as CLB magenta and DES or CLB blue - @MisterChocker (Leon)
 1. [CDU] Added CFDS display test, ATSU METAR/TAF/ATIS requests, and ATSU free text - @wpine215 (Iceman), @nistei (Nistei), @Edwin B
+1. [CDU] Fixed error messages delete input - @MisterChocker (Leon)
+1. [CDU] Added input delay paging left/right and input 1-6L/1-6R - @MisterChocker (Leon)
 1. [GPWS] Completely redone GPWS logic, and improve Retard call logic, prevent multiple calls playing at once - lukecologne (luke)
 1. [ECAM] Improve flaps/slats panel design on upper ECAM, improve flaps/slats transition logic - @paul92ilm (Lussion)
 1. [CDU] Allow inserting landing QNH in inHg - @pessip (Pessi Päivärinne)

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirportsMonitor.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirportsMonitor.js
@@ -212,26 +212,20 @@ class CDUAirportsMonitor {
 
         // user-selected 5th airport (only possible to set on page 1)
         if (!this.page2) {
-            mcdu.onLeftInput[4] = () => {
+            mcdu.onLeftInput[4] = (value) => {
                 if (this.user_ap) {
-                    if (mcdu.inOut === FMCMainDisplay.clrValue) {
+                    if (value === FMCMainDisplay.clrValue) {
                         this.user_ap = undefined;
-                        mcdu.clearUserInput();
                         // trigger data update next frame
                         this.total_delta_t = update_ival_ms;
                         this.ShowPage(mcdu);
-                    } else {
-                        console.log(`"${mcdu.inOut}"`);
-                        console.log(`"${FMCMainDisplay.clrValue}"`);
                     }
-                } else if (mcdu.inOut !== '' && mcdu.inOut !== FMCMainDisplay.clrValue) {
-                    const ap = mcdu.inOut;
+                } else if (value !== '' && value !== FMCMainDisplay.clrValue) {
                     // GetAirportByIdent returns a Waypoint in the callback,
                     // which interally uses FacilityLoader (and further down calls Coherence)
-                    mcdu.dataManager.GetAirportByIdent(ap).then((ap_data) => {
+                    mcdu.dataManager.GetAirportByIdent(value).then((ap_data) => {
                         if (ap_data) {
                             this.user_ap = ap_data;
-                            mcdu.clearUserInput();
                             // trigger data update next frame
                             this.total_delta_t = update_ival_ms;
                             this.frozen = false;
@@ -251,6 +245,10 @@ class CDUAirportsMonitor {
             // trigger data update next frame
             this.total_delta_t = update_ival_ms;
             this.ShowPage(mcdu);
+        };
+
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         // EFOB/WIND

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_AirwaysFromWaypointPage.js
@@ -38,19 +38,15 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                 if (!pendingAirway) {
                     subRows[i] = ["VIA", ""];
                     rows[i] = ["[ ][color]blue", ""];
-                    mcdu.onRightInput[i] = async () => {
-                        const value = mcdu.inOut;
+                    mcdu.onRightInput[i] = async (value) => {
                         if (value.length > 0) {
-                            mcdu.clearUserInput();
                             mcdu.insertWaypoint(value, mcdu.flightPlanManager.getEnRouteWaypointsLastIndex() + 1, () => {
                                 A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, waypoint, offset);
                             });
                         }
                     };
-                    mcdu.onLeftInput[i] = async () => {
-                        const value = mcdu.inOut;
+                    mcdu.onLeftInput[i] = async (value) => {
                         if (value.length > 0) {
-                            mcdu.clearUserInput();
                             mcdu.ensureCurrentFlightPlanIsTemporary(() => {
                                 const lastWaypoint = mcdu.flightPlanManager.getWaypoints()[mcdu.flightPlanManager.getEnRouteWaypointsLastIndex()];
                                 if (lastWaypoint.infos instanceof IntersectionInfo || lastWaypoint.infos instanceof VORInfo || lastWaypoint.infos instanceof NDBInfo) {
@@ -69,10 +65,8 @@ class A320_Neo_CDU_AirwaysFromWaypointPage {
                 } else if (pendingAirway) {
                     subRows[i] = ["VIA", "TO"];
                     rows[i] = [`${pendingAirway.name}[color]blue`, "[ ][color]blue"];
-                    mcdu.onRightInput[i] = () => {
-                        const value = mcdu.inOut;
+                    mcdu.onRightInput[i] = (value) => {
                         if (value.length > 0) {
-                            mcdu.clearUserInput();
                             mcdu.ensureCurrentFlightPlanIsTemporary(() => {
                                 mcdu.insertWaypointsAlongAirway(value, mcdu.flightPlanManager.getEnRouteWaypointsLastIndex() + 1, pendingAirway.name, (result) => {
                                     if (result) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DataIndexPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DataIndexPage.js
@@ -19,20 +19,40 @@ class CDUDataIndexPage {
             ["<POINT", "FUNCTION>"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[0] = () => {
             CDUPositionMonitorPage.ShowPage(mcdu);
+        };
+
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onLeftInput[1] = () => {
             CDUIRSMonitor.ShowPage(mcdu);
         };
 
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[2] = () => {
             CDUGPSMonitor.ShowPage(mcdu);
         };
 
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[3] = () => {
             CDUIdentPage.ShowPage(mcdu);
+        };
+
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onLeftInput[4] = () => {
@@ -70,12 +90,24 @@ class CDUDataIndexPage {
             CDUWaypointPage.ShowPage(mcdu);
         };
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onRightInput[0] = () => {
             CDUPilotsWaypoint.ShowPage(mcdu);
         };
 
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[1] = () => {
             CDUNavaidPage.ShowPage(mcdu);
+        };
+
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onNextPage = () => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_DirectToPage.js
@@ -21,9 +21,7 @@ class CDUDirectToPage {
                 CDUDirectToPage.ShowPage(mcdu);
             };
         }
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[0] = (value) => {
             mcdu.getOrSelectWaypointByIdent(value, (w) => {
                 if (w) {
                     SimVar.SetSimVarValue("L:A320_NEO_PREVIEW_DIRECT_TO", "number", 1);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FlightPlanPage.js
@@ -135,8 +135,10 @@ class CDUFlightPlanPage {
             if (index === 0 && first === 0) {
                 rows[2 * i] = ["FROM", "SPD/ALT", isFlying ? "UTC" : "TIME"];
                 rows[2 * i + 1] = [originIdentCell + "[color]green", "---/ ---[color]green", originTimeCell + "[color]green"];
-                mcdu.onLeftInput[i] = async () => {
-                    const value = mcdu.inOut;
+                mcdu.leftInputDelay[i] = () => {
+                    return mcdu.getDelaySwitchPage();
+                };
+                mcdu.onLeftInput[i] = async (value) => {
                     if (value === "") {
                         CDULateralRevisionPage.ShowPage(mcdu, mcdu.flightPlanManager.getOrigin(), 0);
                     }
@@ -151,9 +153,10 @@ class CDUFlightPlanPage {
                     } else {
                         destTimeCell = FMCMainDisplay.secondsTohhmm(mcdu.flightPlanManager.getDestination().liveETATo);
                     }
-                    mcdu.onLeftInput[i] = () => {
-                        const value = mcdu.inOut;
-                        mcdu.clearUserInput();
+                    mcdu.leftInputDelay[i] = () => {
+                        return mcdu.getDelaySwitchPage();
+                    };
+                    mcdu.onLeftInput[i] = (value) => {
                         if (value === "") {
                             CDULateralRevisionPage.ShowPage(mcdu, mcdu.flightPlanManager.getDestination(), mcdu.flightPlanManager.getWaypointsCount() - 1);
                         } else if (value === FMCMainDisplay.clrValue) {
@@ -275,9 +278,15 @@ class CDUFlightPlanPage {
                         }
 
                         if (fpIndex !== -42) {
-                            mcdu.onLeftInput[i] = async () => {
-                                const value = mcdu.inOut;
-                                mcdu.clearUserInput();
+                            mcdu.leftInputDelay[i] = (value) => {
+                                if (value === "") {
+                                    if (waypoint) {
+                                        return mcdu.getDelaySwitchPage();
+                                    }
+                                }
+                                return mcdu.getDelayBasic();
+                            };
+                            mcdu.onLeftInput[i] = async (value) => {
                                 if (value === "") {
                                     if (waypoint) {
                                         CDULateralRevisionPage.ShowPage(mcdu, waypoint, fpIndex);
@@ -291,6 +300,9 @@ class CDUFlightPlanPage {
                                         CDUFlightPlanPage.ShowPage(mcdu, offset);
                                     });
                                 }
+                            };
+                            mcdu.rightInputDelay[i] = () => {
+                                return mcdu.getDelaySwitchPage();
                             };
                             mcdu.onRightInput[i] = async () => {
                                 if (waypoint) {
@@ -308,6 +320,9 @@ class CDUFlightPlanPage {
                                 [waypoint.ident + "[color]" + color, speedConstraint + "/" + altitudeConstraint + "[s-text][color]" + color, timeCell + "[color]" + color]
                             ];
 
+                            mcdu.rightInputDelay[i + 1] = () => {
+                                return mcdu.getDelaySwitchPage();
+                            };
                             // place the button input on the HOLD line to clear the hold
                             mcdu.onRightInput[i + 1] = async () => {
                                 // TODO remove any active waypoints and route to active waypoint
@@ -339,6 +354,9 @@ class CDUFlightPlanPage {
                         }
                         rows[2 * i] = ["DEST", "DIST EFOB", isFlying ? "UTC" : "TIME"];
                         rows[2 * i + 1] = [destCell, destDistCell + " ----", destTimeCell];
+                        mcdu.leftInputDelay[i] = () => {
+                            return mcdu.getDelaySwitchPage();
+                        };
                         mcdu.onLeftInput[i] = () => {
                             CDULateralRevisionPage.ShowPage(mcdu, mcdu.flightPlanManager.getDestination(), mcdu.flightPlanManager.getWaypointsCount() - 1);
                         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_FuelPredPage.js
@@ -23,9 +23,7 @@ class CDUFuelPredPage {
         let zfwCell = "___._";
         let zfwCgCell = (" __._");
         let zfwColor = "[color]red";
-        mcdu.onRightInput[2] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[2] = async (value) => {
             if (await mcdu.trySetZeroFuelWeightZFWCG(value)) {
                 CDUFuelPredPage.ShowPage(mcdu);
             }
@@ -72,9 +70,7 @@ class CDUFuelPredPage {
                         finalColor = "[color]blue";
                     }
                 }
-                mcdu.onLeftInput[4] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[4] = async (value) => {
                     if (await mcdu.trySetRouteFinalFuel(value)) {
                         CDUFuelPredPage.ShowPage(mcdu);
                     }
@@ -94,9 +90,7 @@ class CDUFuelPredPage {
                         altFuelColor = "[color]blue";
                     }
                 }
-                mcdu.onLeftInput[3] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[3] = async (value) => {
                     console.log("Entered Val : " + value);
                     if (await mcdu.trySetRouteAlternateFuel(value)) {
                         CDUFuelPredPage.ShowPage(mcdu);
@@ -144,9 +138,7 @@ class CDUFuelPredPage {
                         rteRsvPercentCell = mcdu.getRouteReservedPercent().toFixed(1);
                         rteRsvPercentCell = rteRsvPercentCell.length <= 3 ? "{sp}" + rteRsvPercentCell : rteRsvPercentCell;
                         rteRSvCellColor = "[color]blue";
-                        mcdu.onLeftInput[2] = async () => {
-                            const value = mcdu.inOut;
-                            mcdu.clearUserInput();
+                        mcdu.onLeftInput[2] = async (value) => {
                             if (await mcdu.trySetRouteReservedFuel(value)) {
                                 CDUInitPage.ShowPage2(mcdu);
                             }
@@ -162,9 +154,7 @@ class CDUFuelPredPage {
                     minDestFobCell = "{sp}{sp}{small}" + mcdu._minDestFob.toFixed(1) + "{end}";
                     minDestFobCellColor = "[color]blue";
                 }
-                mcdu.onLeftInput[5] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[5] = async (value) => {
                     if (await mcdu.trySetMinDestFob(value)) {
                         CDUFuelPredPage.ShowPage(mcdu);
                     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_HoldAtPage.js
@@ -70,13 +70,11 @@ class CDUHoldAtPage {
                 ...rows
             ]);
 
-            mcdu.onLeftInput[0] = () => {
-                const value = mcdu.inOut;
+            mcdu.onLeftInput[0] = (value) => {
                 if (isNaN(value) || 0 < value > 360) {
-                    mcdu.inOut = "NaN";
+                    mcdu.showErrorMessage("ENTRY OUT OF RANGE");
                     return;
                 }
-                mcdu.clearUserInput();
                 mcdu.manualHoldData = {
                     time: holdTime,
                     course: parseFloat(value),
@@ -86,13 +84,11 @@ class CDUHoldAtPage {
                 CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
             };
 
-            mcdu.onLeftInput[1] = () => {
-                const value = mcdu.inOut;
+            mcdu.onLeftInput[1] = (value) => {
                 if (value != "L" && value != "R") {
-                    mcdu.inOut = "ERR FMT";
+                    mcdu.showErrorMessage("FORMAT ERROR");
                     return;
                 }
-                mcdu.clearUserInput();
                 mcdu.manualHoldData = {
                     time: holdTime,
                     course: holdCourse,
@@ -102,16 +98,13 @@ class CDUHoldAtPage {
                 CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
             };
 
-            mcdu.onLeftInput[2] = () => {
-                const value = mcdu.inOut;
-
+            mcdu.onLeftInput[2] = (value) => {
                 if (value.startsWith("/")) {
                     const distComp = value.replace("/", "");
                     if (isNaN(distComp)) {
-                        mcdu.inOut = "ERR FMT";
+                        mcdu.showErrorMessage("FORMAT ERROR");
                         return;
                     }
-                    mcdu.clearUserInput();
                     mcdu.manualHoldData = {
                         time: parseFloat(distComp) / estimatedTAS,
                         course: holdCourse,
@@ -124,13 +117,12 @@ class CDUHoldAtPage {
                 }
 
                 if (isNaN(value)) {
-                    mcdu.inOut = "ERR FMT";
+                    mcdu.showErrorMessage("FORMAT ERROR");
                     return;
                 }
 
                 holdDistance = estimatedTAS * parseFloat(value);
 
-                mcdu.clearUserInput();
                 mcdu.manualHoldData = {
                     time: value,
                     course: holdCourse,

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSInit.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSInit.js
@@ -127,6 +127,10 @@ class CDUIRSInit {
             lon = true;
         };
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[5] = () => {
             CDUInitPage.ShowPage1(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSMonitor.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSMonitor.js
@@ -27,12 +27,20 @@ class CDUIRSMonitor {
             ["<IRS3"],
             [`${IRSStatus}[color]green`],
         ]);
-
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDUIRSStatus.ShowPage(mcdu, 1);
         };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[1] = () => {
             CDUIRSStatus.ShowPage(mcdu, 2);
+        };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[2] = () => {
             CDUIRSStatus.ShowPage(mcdu, 3);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSStatus.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_IRSStatus.js
@@ -55,6 +55,10 @@ class CDUIRSStatus {
             CDUIRSStatusFrozen.ShowPage(mcdu, index, wind_dir);
         };
 
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onRightInput[5] = () => {
             if (index > 2) {
                 CDUIRSMonitor.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_InitPage.js
@@ -34,9 +34,7 @@ class CDUInitPage {
                 }
 
                 // Cost index
-                mcdu.onLeftInput[4] = () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[4] = (value) => {
                     if (mcdu.tryUpdateCostIndex(value)) {
                         CDUInitPage.ShowPage1(mcdu);
                     }
@@ -56,10 +54,8 @@ class CDUInitPage {
                 }
 
                 // CRZ FL / FLX TEMP
-                mcdu.onLeftInput[5] = () => {
+                mcdu.onLeftInput[5] = (value) => {
                     mcdu._cruiseEntered = true;
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
                     if (mcdu.setCruiseFlightLevelAndTemperature(value)) {
                         CDUInitPage.ShowPage1(mcdu);
                     }
@@ -76,14 +72,12 @@ class CDUInitPage {
                 } else {
                     altDest = "NONE" + "[color]blue";
                 }
-                mcdu.onLeftInput[1] = async () => {
-                    const value = mcdu.inOut;
+                mcdu.onLeftInput[1] = async (value) => {
                     switch (altDest) {
                         case "NONE":
                             if (value === "") {
                                 CDUAvailableFlightPlanPage.ShowPage(mcdu);
                             } else {
-                                mcdu.clearUserInput();
                                 if (await mcdu.tryUpdateAltDestination(value)) {
                                     CDUInitPage.ShowPage1(mcdu);
                                 }
@@ -93,7 +87,6 @@ class CDUInitPage {
                             if (value === "") {
                                 CDUAvailableFlightPlanPage.ShowPage(mcdu);
                             } else {
-                                mcdu.clearUserInput();
                                 if (await mcdu.tryUpdateAltDestination(value)) {
                                     CDUInitPage.ShowPage1(mcdu);
                                 }
@@ -107,9 +100,7 @@ class CDUInitPage {
         if (mcdu.coRoute) {
             coRoute = mcdu.coRoute + "[color]blue";
         }
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[0] = (value) => {
             mcdu.updateCoRoute(value, (result) => {
                 if (result) {
                     CDUInitPage.ShowPage1(mcdu);
@@ -122,10 +113,8 @@ class CDUInitPage {
          * else show route selection pair if city pair is displayed
          * Ref: FCOM 4.03.20 P6
          */
-        mcdu.onRightInput[0] = () => {
-            const value = mcdu.inOut;
+        mcdu.onRightInput[0] = (value) => {
             if (value !== "") {
-                mcdu.clearUserInput();
                 mcdu.tryUpdateFromTo(value, (result) => {
                     if (result) {
                         CDUPerformancePage.UpdateThrRedAccFromOrigin(mcdu);
@@ -139,14 +128,15 @@ class CDUInitPage {
                 }
             }
         };
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[2] = () => {
             if (alignOption) {
                 CDUIRSInit.ShowPage(mcdu);
             }
         };
-        mcdu.onLeftInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[2] = (value) => {
             mcdu.updateFlightNo(value, (result) => {
                 if (result) {
                     CDUInitPage.ShowPage1(mcdu);
@@ -239,9 +229,7 @@ class CDUInitPage {
                 zfwColor = "[color]blue";
             }
         }
-        mcdu.onRightInput[0] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[0] = async (value) => {
             if (value === "") {
                 mcdu.inOut =
                     (isFinite(mcdu.zeroFuelWeight) ? mcdu.zeroFuelWeight.toFixed(1) : "") +
@@ -262,9 +250,7 @@ class CDUInitPage {
                 blockFuelColor = "[color]blue";
             }
         }
-        mcdu.onRightInput[1] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[1] = async (value) => {
             if (mcdu._zeroFuelWeightZFWCGEntered && value !== mcdu.clrValue) { //Simulate delay if calculating trip data
                 if (await mcdu.trySetBlockFuel(value)) {
                     CDUInitPage.updateTowIfNeeded(mcdu);
@@ -319,9 +305,7 @@ class CDUInitPage {
                 taxiFuelCell = "{small}" + mcdu.taxiFuelWeight.toFixed(1) + "{end}";
             }
         }
-        mcdu.onLeftInput[0] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[0] = async (value) => {
             if (mcdu._fuelPredDone) {
                 setTimeout(async () => {
                     if (await mcdu.trySetTaxiFuelWeight(value)) {
@@ -349,9 +333,7 @@ class CDUInitPage {
         if (isFinite(mcdu.getRouteReservedPercent())) {
             rteRsvPercentCell = "{blue}" + mcdu.getRouteReservedPercent().toFixed(1) + "{end}";
         }
-        mcdu.onLeftInput[2] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[2] = async (value) => {
             if (await mcdu.trySetRouteReservedPercent(value)) {
                 CDUInitPage.ShowPage2(mcdu);
             }
@@ -367,9 +349,7 @@ class CDUInitPage {
         if (mcdu.getRouteFinalFuelTime() > 0) {
             finalTimeCell = "{blue}" + FMCMainDisplay.minutesTohhmm(mcdu.getRouteFinalFuelTime()) + "{end}";
         }
-        mcdu.onLeftInput[4] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[4] = async (value) => {
             if (await mcdu.trySetRouteFinalTime(value)) {
                 CDUInitPage.ShowPage2(mcdu);
             }
@@ -384,9 +364,7 @@ class CDUInitPage {
 
         let tripWindColor = "[color]blue";
         let tripWindCell = "{small}" + mcdu._windDir + mcdu.averageWind.toFixed(0).padStart(3, "0") + "{end}";
-        mcdu.onRightInput[4] = async () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[4] = async (value) => {
             if (await mcdu.trySetAverageWind(value)) {
                 CDUInitPage.ShowPage2(mcdu);
             }
@@ -419,9 +397,7 @@ class CDUInitPage {
                         finalColor = "[color]blue";
                     }
                 }
-                mcdu.onLeftInput[4] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[4] = async (value) => {
                     setTimeout(async () => {
                         if (await mcdu.trySetRouteFinalFuel(value)) {
                             if (mcdu.page.Current === mcdu.page.InitPageB) {
@@ -445,9 +421,7 @@ class CDUInitPage {
                         altnColor = "[color]blue";
                     }
                 }
-                mcdu.onLeftInput[3] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[3] = async (value) => {
                     setTimeout(async () => {
                         if (await mcdu.trySetRouteAlternateFuel(value)) {
                             if (mcdu.page.Current === mcdu.page.InitPageB) {
@@ -479,9 +453,7 @@ class CDUInitPage {
                         rteRsvColor = "[color]blue";
                     }
                 }
-                mcdu.onLeftInput[2] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[2] = async (value) => {
                     setTimeout(async () => {
                         if (await mcdu.trySetRouteReservedFuel(value)) {
                             if (mcdu.page.Current === mcdu.page.InitPageB) {
@@ -500,9 +472,7 @@ class CDUInitPage {
                 if (isFinite(mcdu.averageWind)) {
                     tripWindCell = "{small}" + mcdu._windDir + mcdu.averageWind.toFixed(0).padStart(3, "0") + "{end}";
                 }
-                mcdu.onRightInput[4] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onRightInput[4] = async (value) => {
                     setTimeout(async () => {
                         if (await mcdu.trySetAverageWind(value)) {
                             if (mcdu.page.Current === mcdu.page.InitPageB) {
@@ -520,9 +490,7 @@ class CDUInitPage {
                     minDestFob = "{sp}{sp}{small}" + mcdu._minDestFob.toFixed(1) + "{end}";
                     minDestFobColor = "[color]blue";
                 }
-                mcdu.onLeftInput[5] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onLeftInput[5] = async (value) => {
                     if (await mcdu.trySetMinDestFob(value)) {
                         CDUInitPage.ShowPage2(mcdu);
                     }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_LateralRevisionPage.js
@@ -34,6 +34,9 @@ class CDULateralRevisionPage {
         let departureCell = "";
         if (isDeparture) {
             departureCell = "<DEPARTURE";
+            mcdu.leftInputDelay[0] = () => {
+                return mcdu.getDelaySwitchPage();
+            };
             mcdu.onLeftInput[0] = () => {
                 CDUAvailableDeparturesPage.ShowPage(mcdu, waypoint);
             };
@@ -42,6 +45,9 @@ class CDULateralRevisionPage {
         let arrivalFixInfoCell = "";
         if (isDestination) {
             arrivalFixInfoCell = "ARRIVAL>";
+            mcdu.rightInputDelay[0] = () => {
+                return mcdu.getDelaySwitchPage();
+            };
             mcdu.onRightInput[0] = () => {
                 CDUAvailableArrivalsPage.ShowPage(mcdu, waypoint);
             };
@@ -72,9 +78,7 @@ class CDULateralRevisionPage {
             } else {
                 nextWptLabel = "NEXT WPT";
                 nextWpt = "[{sp}{sp}{sp}{sp}][color]blue";
-                mcdu.onRightInput[2] = async () => {
-                    const value = mcdu.inOut;
-                    mcdu.clearUserInput();
+                mcdu.onRightInput[2] = async (value) => {
                     mcdu.insertWaypoint(value, waypointIndexFP + 1, (result) => {
                         if (result) {
                             CDUFlightPlanPage.ShowPage(mcdu);
@@ -87,6 +91,9 @@ class CDULateralRevisionPage {
         let holdCell = "";
         if (isWaypoint) {
             holdCell = "<HOLD";
+            mcdu.leftInputDelay[2] = () => {
+                return mcdu.getDelaySwitchPage();
+            };
             mcdu.onLeftInput[2] = () => {
                 CDUHoldAtPage.ShowPage(mcdu, waypoint, waypointIndexFP);
             };
@@ -110,6 +117,9 @@ class CDULateralRevisionPage {
         let airwaysCell = "";
         if (isWaypoint) {
             airwaysCell = "AIRWAYS>";
+            mcdu.rightInputDelay[4] = () => {
+                return mcdu.getDelaySwitchPage();
+            };
             mcdu.onRightInput[4] = () => {
                 A320_Neo_CDU_AirwaysFromWaypointPage.ShowPage(mcdu, waypoint);
             };
@@ -135,6 +145,9 @@ class CDULateralRevisionPage {
             [""],
             ["<RETURN"]
         ]);
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUFlightPlanPage.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -71,7 +71,12 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             CDUFuelPredPage.ShowPage(this);
         };
         this.onMenu = () => {
-            CDUMenuPage.ShowPage(this);
+            const cur = this.page.Current;
+            setTimeout(() => {
+                if (this.page.Current === cur) {
+                    CDUMenuPage.ShowPage(this);
+                }
+            }, this.getDelaySwitchPage());
         };
 
         CDUMenuPage.ShowPage(this);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MenuPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MenuPage.js
@@ -126,35 +126,75 @@ class CDUMenuPage {
 
         mcdu.onDir = () => {
             mcdu.showErrorMessage("");
-            CDUDirectToPage.ShowPage(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUDirectToPage.ShowPage(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onProg = () => {
             mcdu.showErrorMessage("");
-            CDUProgressPage.ShowPage(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUProgressPage.ShowPage(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onPerf = () => {
             mcdu.showErrorMessage("");
-            CDUPerformancePage.ShowPage(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUPerformancePage.ShowPage(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onInit = () => {
             mcdu.showErrorMessage("");
-            CDUInitPage.ShowPage1(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUInitPage.ShowPage1(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onData = () => {
             mcdu.showErrorMessage("");
-            CDUDataIndexPage.ShowPage1(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUDataIndexPage.ShowPage1(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onFpln = () => {
             mcdu.showErrorMessage("");
-            CDUFlightPlanPage.ShowPage(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUFlightPlanPage.ShowPage(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onRad = () => {
             mcdu.showErrorMessage("");
-            CDUNavRadioPage.ShowPage(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUNavRadioPage.ShowPage(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
         mcdu.onFuel = () => {
             mcdu.showErrorMessage("");
-            CDUFuelPredPage.ShowPage(mcdu);
+            const cur = mcdu.page.Current;
+            setTimeout(() => {
+                if (mcdu.page.Current === cur) {
+                    CDUFuelPredPage.ShowPage(mcdu);
+                }
+            }, mcdu.getDelaySwitchPage());
         };
     }
 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavRadioPage.js
@@ -17,10 +17,8 @@ class CDUNavRadioPage {
             if (mcdu.vor1Frequency > 0) {
                 vor1FrequencyCell = "[]/" + mcdu.vor1Frequency.toFixed(2);
             }
-            mcdu.onLeftInput[0] = () => {
-                const value = mcdu.inOut;
+            mcdu.onLeftInput[0] = (value) => {
                 const numValue = parseFloat(value);
-                mcdu.clearUserInput();
                 if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
                     mcdu.vor1Frequency = numValue;
                     if (mcdu.isRadioNavActive()) {
@@ -46,10 +44,8 @@ class CDUNavRadioPage {
             if (mcdu.vor1Course >= 0) {
                 vor1CourseCell = mcdu.vor1Course.toFixed(0) + "°";
             }
-            mcdu.onLeftInput[1] = () => {
-                const value = mcdu.inOut;
+            mcdu.onLeftInput[1] = (value) => {
                 const numValue = parseFloat(value);
-                mcdu.clearUserInput();
                 if (isFinite(numValue) && numValue >= 0 && numValue < 360) {
                     SimVar.SetSimVarValue("K:VOR1_SET", "number", numValue).then(() => {
                         mcdu.vor1Course = numValue;
@@ -76,9 +72,7 @@ class CDUNavRadioPage {
             } else {
                 ilsFrequencyCell += "[ ]";
             }
-            mcdu.onLeftInput[2] = () => {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
+            mcdu.onLeftInput[2] = (value) => {
                 if (mcdu.setIlsFrequency(value)) {
                     CDUNavRadioPage.ShowPage(mcdu);
                 }
@@ -87,10 +81,8 @@ class CDUNavRadioPage {
             if (mcdu.adf1Frequency > 0) {
                 adf1FrequencyCell = "[]/" + mcdu.adf1Frequency.toFixed(2);
             }
-            mcdu.onLeftInput[4] = () => {
-                const value = mcdu.inOut;
+            mcdu.onLeftInput[4] = (value) => {
                 const numValue = parseFloat(value);
-                mcdu.clearUserInput();
                 if (isFinite(numValue) && numValue >= 100 && numValue <= 1699.9) {
                     SimVar.SetSimVarValue("K:ADF_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(numValue * 1000)).then(() => {
                         mcdu.adf1Frequency = numValue;
@@ -111,10 +103,8 @@ class CDUNavRadioPage {
             if (mcdu.vor2Frequency > 0) {
                 vor2FrequencyCell = "[]/" + mcdu.vor2Frequency.toFixed(2);
             }
-            mcdu.onRightInput[0] = () => {
-                const value = mcdu.inOut;
+            mcdu.onRightInput[0] = (value) => {
                 const numValue = parseFloat(value);
-                mcdu.clearUserInput();
                 if (isFinite(numValue) && numValue >= 108 && numValue <= 117.95 && RadioNav.isHz50Compliant(numValue)) {
                     mcdu.vor2Frequency = numValue;
                     if (mcdu.isRadioNavActive()) {
@@ -140,10 +130,8 @@ class CDUNavRadioPage {
             if (mcdu.vor2Course >= 0) {
                 vor2CourseCell = mcdu.vor2Course.toFixed(0) + "°";
             }
-            mcdu.onRightInput[1] = () => {
-                const value = mcdu.inOut;
+            mcdu.onRightInput[1] = (value) => {
                 const numValue = parseFloat(value);
-                mcdu.clearUserInput();
                 if (isFinite(numValue) && numValue >= 0 && numValue < 360) {
                     SimVar.SetSimVarValue("K:VOR2_SET", "number", numValue).then(() => {
                         mcdu.vor2Course = numValue;
@@ -159,10 +147,8 @@ class CDUNavRadioPage {
             if (mcdu.adf2Frequency > 0) {
                 adf2FrequencyCell = mcdu.adf2Frequency.toFixed(2) + "/[]";
             }
-            mcdu.onRightInput[4] = () => {
-                const value = mcdu.inOut;
+            mcdu.onRightInput[4] = (value) => {
                 const numValue = parseFloat(value);
-                mcdu.clearUserInput();
                 if (isFinite(numValue) && numValue >= 100 && numValue <= 1699.9) {
                     SimVar.SetSimVarValue("K:ADF2_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(numValue * 1000)).then(() => {
                         mcdu.adf2Frequency = numValue;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_NavaidPage.js
@@ -24,18 +24,14 @@ class CDUNavaidPage {
             [""]
         ]);
 
-        mcdu.onLeftInput[0] = () => {
-            const INPUT = mcdu.inOut;
-            mcdu.clearUserInput();
-
-            const selectedWaypoint = mcdu.getOrSelectWaypointByIdent(INPUT, res => {
-
+        mcdu.onLeftInput[0] = (value) => {
+            const selectedWaypoint = mcdu.getOrSelectWaypointByIdent(value, res => {
                 if (res) {
                     mcdu.clearDisplay();
                     mcdu.setTemplate([
                         ["NAVAID"],
                         ["IDENT"],
-                        [`${INPUT}`],
+                        [`${value}`],
                         ["LAT/LONG"],
                         [`${new LatLong(res.infos.coordinates.lat, res.infos.coordinates.long).toShortDegreeString()}[color]green`],
                         [""],
@@ -49,7 +45,7 @@ class CDUNavaidPage {
                     ]);
                     mcdu.inOut = Object.keys(res);
                 } else {
-                    mcdu.inOut = "INVALID ENTRY";
+                    mcdu.showErrorMessage(mcdu.defaultInputErrorMessage);
                 }
             });
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PerformancePage.js
@@ -48,9 +48,7 @@ class CDUPerformancePage {
         if (mcdu.v1Speed) {
             v1 = mcdu.v1Speed + "[color]blue";
         }
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[0] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 mcdu.v1Speed = undefined;
                 SimVar.SetSimVarValue("L:AIRLINER_V1_SPEED", "Knots", -1);
@@ -68,9 +66,7 @@ class CDUPerformancePage {
         if (mcdu.vRSpeed) {
             vR = mcdu.vRSpeed + "[color]blue";
         }
-        mcdu.onLeftInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[1] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 mcdu.vRSpeed = undefined;
                 SimVar.SetSimVarValue("L:AIRLINER_VR_SPEED", "Knots", -1);
@@ -88,9 +84,7 @@ class CDUPerformancePage {
         if (mcdu.v2Speed) {
             v2 = mcdu.v2Speed + "[color]blue";
         }
-        mcdu.onLeftInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[2] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 mcdu.v2Speed = undefined;
                 SimVar.SetSimVarValue("L:AIRLINER_V2_SPEED", "Knots", -1);
@@ -108,9 +102,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.transitionAltitude)) {
             transAlt = mcdu.transitionAltitude + "[color]blue";
         }
-        mcdu.onLeftInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[3] = (value) => {
             if (mcdu.trySetTransAltitude(value)) {
                 CDUPerformancePage.ShowTAKEOFFPage(mcdu);
             }
@@ -128,9 +120,7 @@ class CDUPerformancePage {
             thrRedAcc += "---";
         }
         thrRedAcc += "[color]blue";
-        mcdu.onLeftInput[4] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[4] = (value) => {
             if (mcdu.trySetThrustReductionAccelerationAltitude(value)) {
                 CDUPerformancePage.ShowTAKEOFFPage(mcdu);
             }
@@ -159,9 +149,7 @@ class CDUPerformancePage {
                 flapsThs += "[]";
             }
         }
-        mcdu.onRightInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[2] = (value) => {
             if (mcdu.trySetFlapsTHS(value)) {
                 CDUPerformancePage.ShowTAKEOFFPage(mcdu);
             }
@@ -170,9 +158,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.perfTOTemp)) {
             flexTakeOffTempCell = mcdu.perfTOTemp + "°";
         }
-        mcdu.onRightInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[3] = (value) => {
             if (mcdu.setPerfTOFlexTemp(value)) {
                 CDUPerformancePage.ShowTAKEOFFPage(mcdu);
             }
@@ -192,6 +178,9 @@ class CDUPerformancePage {
             ["", "NEXT"],
             ["", "PHASE>"]
         ]);
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[5] = () => {
             CDUPerformancePage.ShowCLBPage(mcdu);
         };
@@ -240,16 +229,12 @@ class CDUPerformancePage {
         } else {
             selectedSpeedCell = "[]";
         }
-        mcdu.onLeftInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[1] = (value) => {
             if (mcdu.tryUpdateCostIndex(value)) {
                 CDUPerformancePage.ShowCLBPage(mcdu);
             }
         };
-        mcdu.onLeftInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[3] = (value) => {
             if (mcdu.trySetPreSelectedClimbSpeed(value)) {
                 CDUPerformancePage.ShowCLBPage(mcdu);
             }
@@ -260,6 +245,9 @@ class CDUPerformancePage {
         }
         const bottomRowLabels = ["PREV", "NEXT"];
         const bottomRowCells = ["<PHASE", "PHASE>"];
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         if (mcdu.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
             if (confirmAppr) {
                 bottomRowLabels[0] = "CONFIRM[color]red";
@@ -281,6 +269,9 @@ class CDUPerformancePage {
                 CDUPerformancePage.ShowTAKEOFFPage(mcdu);
             };
         }
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[5] = () => {
             CDUPerformancePage.ShowCRZPage(mcdu);
         };
@@ -339,16 +330,12 @@ class CDUPerformancePage {
         } else {
             selectedSpeedCell = "[]";
         }
-        mcdu.onLeftInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[1] = (value) => {
             if (mcdu.tryUpdateCostIndex(value)) {
                 CDUPerformancePage.ShowCLBPage(mcdu);
             }
         };
-        mcdu.onLeftInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[3] = (value) => {
             if (mcdu.trySetPreSelectedCruiseSpeed(value)) {
                 CDUPerformancePage.ShowCRZPage(mcdu);
             }
@@ -359,6 +346,9 @@ class CDUPerformancePage {
         }
         const bottomRowLabels = ["PREV", "NEXT"];
         const bottomRowCells = ["<PHASE", "PHASE>"];
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         if (mcdu.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CRUISE) {
             if (confirmAppr) {
                 bottomRowLabels[0] = "CONFIRM[color]red";
@@ -380,6 +370,9 @@ class CDUPerformancePage {
                 CDUPerformancePage.ShowCLBPage(mcdu);
             };
         }
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[5] = () => {
             CDUPerformancePage.ShowDESPage(mcdu);
         };
@@ -438,9 +431,7 @@ class CDUPerformancePage {
         } else {
             selectedSpeedCell = "[]";
         }
-        mcdu.onLeftInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[3] = (value) => {
             if (mcdu.trySetPreSelectedDescentSpeed(value)) {
                 CDUPerformancePage.ShowDESPage(mcdu);
             }
@@ -451,6 +442,9 @@ class CDUPerformancePage {
         }
         const bottomRowLabels = ["PREV", "NEXT"];
         const bottomRowCells = ["<PHASE", "PHASE>"];
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         if (mcdu.currentFlightPhase === FlightPhase.FLIGHT_PHASE_DESCENT) {
             if (confirmAppr) {
                 bottomRowLabels[0] = "CONFIRM[color]red";
@@ -472,12 +466,13 @@ class CDUPerformancePage {
                 CDUPerformancePage.ShowCRZPage(mcdu);
             };
         }
-        mcdu.onLeftInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[1] = (value) => {
             if (mcdu.tryUpdateCostIndex(value)) {
                 CDUPerformancePage.ShowCLBPage(mcdu);
             }
+        };
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[5] = () => {
             CDUPerformancePage.ShowAPPRPage(mcdu);
@@ -520,9 +515,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.perfApprQNH) || QNH_REGEX.test(mcdu.perfApprQNH)) {
             qnhCell = mcdu.perfApprQNH;
         }
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[0] = (value) => {
             if (mcdu.setPerfApprQNH(value)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -531,9 +524,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.perfApprTemp)) {
             tempCell = mcdu.perfApprTemp.toFixed(0);
         }
-        mcdu.onLeftInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[1] = (value) => {
             if (mcdu.setPerfApprTemp(value)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -546,9 +537,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.perfApprWindSpeed)) {
             magWindSpeedCell = mcdu.perfApprWindSpeed.toFixed(0);
         }
-        mcdu.onLeftInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[2] = (value) => {
             if (mcdu.setPerfApprWind(value)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -557,9 +546,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.perfApprTransAlt)) {
             transAltCell = mcdu.perfApprTransAlt.toFixed(0);
         }
-        mcdu.onLeftInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[3] = (value) => {
             if (mcdu.setPerfApprTransAlt(value)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -569,9 +556,7 @@ class CDUPerformancePage {
         if (isFinite(vApp)) {
             vappCell = vApp.toFixed(0);
         }
-        mcdu.onLeftInput[4] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[4] = (value) => {
             if (mcdu.setPerfApprVApp(value)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -590,9 +575,7 @@ class CDUPerformancePage {
         if (isFinite(mcdu.perfApprMDA)) {
             mdaCell = mcdu.perfApprMDA.toFixed(0);
         }
-        mcdu.onRightInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[1] = (value) => {
             if (mcdu.setPerfApprMDA(value) && mcdu.setPerfApprDH(FMCMainDisplay.clrValue)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -603,9 +586,7 @@ class CDUPerformancePage {
         } else if (mcdu.perfApprDH === "NO DH") {
             dhCell = "NO DH";
         }
-        mcdu.onRightInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[2] = (value) => {
             if (mcdu.setPerfApprDH(value) && mcdu.setPerfApprMDA(FMCMainDisplay.clrValue)) {
                 CDUPerformancePage.ShowAPPRPage(mcdu);
             }
@@ -640,8 +621,14 @@ class CDUPerformancePage {
             ["PREV", "NEXT"],
             ["<PHASE", "PHASE>"]
         ]);
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUPerformancePage.ShowDESPage(mcdu);
+        };
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[5] = () => {
             CDUPerformancePage.ShowGOAROUNDPage(mcdu);
@@ -735,6 +722,9 @@ class CDUPerformancePage {
             ["PREV"],
             ["<PHASE"]
         ]);
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUPerformancePage.ShowAPPRPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PilotsWaypoint.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PilotsWaypoint.js
@@ -17,6 +17,10 @@ class CDUPilotsWaypoint {
             ["", "DELETE ALL}[color]blue"]
         ]);
 
+        mcdu.rightInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onRightInput[4] = () => {
             CDUNewWaypoint.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PositionMonitorPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_PositionMonitorPage.js
@@ -35,6 +35,10 @@ class CDUPositionMonitorPage {
             ["{FREEZE[color]blue", "NAVAIDS>"]
         ]);
 
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onRightInput[5] = () => {
             CDUSelectedNavaids.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_ProgressPage.js
@@ -30,15 +30,19 @@ class CDUProgressPage {
                 break;
             }
         }
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
+        mcdu.onLeftInput[0] = (value) => {
             if (mcdu.trySetCruiseFlCheckInput(value)) {
-                mcdu.clearUserInput();
                 CDUProgressPage.ShowPage(mcdu);
             }
         };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[1] = () => {
             CDUProgressPage.ShowReportPage(mcdu);
+        };
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[4] = () => {
             CDUProgressPage.ShowPredictiveGPSPage(mcdu);
@@ -71,9 +75,7 @@ class CDUProgressPage {
         if (isFinite(mcdu.cruiseFlightLevel)) {
             altCell = mcdu.cruiseFlightLevel.toFixed(0);
         }
-        mcdu.onRightInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onRightInput[0] = (value) => {
             if (mcdu.setCruiseFlightLevelAndTemperature(value)) {
                 CDUProgressPage.ShowReportPage(mcdu);
             }
@@ -148,9 +150,7 @@ class CDUProgressPage {
             } else {
                 destETACell = FMCMainDisplay.secondsTohhmm(mcdu.flightPlanManager.getDestination().infos.etaInFP);
             }
-            mcdu.onRightInput[0] = () => {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
+            mcdu.onRightInput[0] = (value) => {
                 CDUProgressPage.ShowPredictiveGPSPage(mcdu, value);
             };
         }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_SelectedNavaids.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_SelectedNavaids.js
@@ -19,6 +19,10 @@ class CDUSelectedNavaids {
             ["DESELECT", "RETURN>"]
         ]);
 
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onRightInput[5] = () => {
             CDUDataIndexPage.ShowPage1(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_VerticalRevisionPage.js
@@ -56,21 +56,18 @@ class CDUVerticalRevisionPage {
             mcdu.onRightInput[0] = () => {}; // EXTRA
             mcdu.onLeftInput[1] = () => {}; // CLB SPD LIM
             mcdu.onRightInput[1] = () => {}; // RTA
-            mcdu.onLeftInput[2] = async () => {
-                const value = parseInt(mcdu.inOut);
+            mcdu.onLeftInput[2] = async (value) => {
                 if (isFinite(value)) {
                     if (value >= 0) {
                         // NYI
                     }
                 }
-                mcdu.clearUserInput();
                 mcdu.showErrorMessage("NOT YET IMPLEMENTED");
                 setTimeout(() => {
                     mcdu.showErrorMessage("");
                 }, 1000);
             }; // SPD CSTR
-            mcdu.onRightInput[2] = () => {
-                let value = mcdu.inOut;
+            mcdu.onRightInput[2] = (value) => {
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.removeWaypoint(fpIndex, () => {
                         CDUFlightPlanPage.ShowPage(mcdu, offset);
@@ -79,7 +76,6 @@ class CDUVerticalRevisionPage {
                 value = parseInt(value);
                 if (isFinite(value)) {
                     if (value >= 0) {
-                        mcdu.clearUserInput();
                         mcdu.flightPlanManager.setWaypointAltitude((value < 1000 ? value * 100 : value) / 3.28084, mcdu.flightPlanManager.indexOfWaypoint(waypoint), () => {
                             this.ShowPage(mcdu, waypoint);
                         });

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_WaypointPage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_WaypointPage.js
@@ -24,17 +24,14 @@ class CDUWaypointPage {
             [""]
         ]);
 
-        mcdu.onLeftInput[0] = () => {
-            const INPUT = mcdu.inOut;
-            mcdu.clearUserInput();
-
-            const selectedWaypoint = mcdu.getOrSelectWaypointByIdent(INPUT, res => {
+        mcdu.onLeftInput[0] = (value) => {
+            const selectedWaypoint = mcdu.getOrSelectWaypointByIdent(value, res => {
                 if (res) {
                     mcdu.clearDisplay();
                     mcdu.setTemplate([
                         ["WAYPOINT"],
                         ["IDENT"],
-                        [`${INPUT}`],
+                        [`${value}`],
                         ["LAT/LONG"],
                         [`${new LatLong(res.infos.coordinates.lat, res.infos.coordinates.long).toShortDegreeString()}[color]green`],
                         [""],
@@ -47,7 +44,7 @@ class CDUWaypointPage {
                         [""]
                     ]);
                 } else {
-                    mcdu.inOut = "INVALID ENTRY";
+                    mcdu.showErrorMessage(mcdu.defaultInputErrorMessage);
                 }
             });
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/AIDS/A320_Neo_CDU_AIDS_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/AIDS/A320_Neo_CDU_AIDS_Menu.js
@@ -18,6 +18,9 @@ class CDU_AIDS_MainMenu {
             ["DAR = RUNNING[color]green", "STOP*[color]blue"]
         ]);
 
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[5] = () => {
             mcdu.showErrorMessage("NOT YET IMPLEMENTED");
             setTimeout(() => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_FreeText.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_FreeText.js
@@ -21,9 +21,7 @@ class CDUAocFreeText {
         };
         updateView();
 
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[0] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["msg_to"] = "";
             } else {
@@ -32,9 +30,7 @@ class CDUAocFreeText {
             CDUAocFreeText.ShowPage(mcdu, store);
         };
 
-        mcdu.onLeftInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[1] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["msg_line1"] = "";
             } else {
@@ -43,9 +39,7 @@ class CDUAocFreeText {
             CDUAocFreeText.ShowPage(mcdu, store);
         };
 
-        mcdu.onLeftInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[2] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["msg_line2"] = "";
             } else {
@@ -54,9 +48,7 @@ class CDUAocFreeText {
             CDUAocFreeText.ShowPage(mcdu, store);
         };
 
-        mcdu.onLeftInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[3] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["msg_line3"] = "";
             } else {
@@ -65,9 +57,7 @@ class CDUAocFreeText {
             CDUAocFreeText.ShowPage(mcdu, store);
         };
 
-        mcdu.onLeftInput[4] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.onLeftInput[4] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["msg_line4"] = "";
             } else {
@@ -76,6 +66,9 @@ class CDUAocFreeText {
             CDUAocFreeText.ShowPage(mcdu, store);
         };
 
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[5] = async () => {
             const storedTelexStatus = NXDataStore.get("CONFIG_TELEX_STATUS", "DISABLED");
 
@@ -141,6 +134,10 @@ class CDUAocFreeText {
             } else {
                 mcdu.showErrorMessage("TELEX NOT ENABLED");
             }
+        };
+
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onLeftInput[5] = () => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_Menu.js
@@ -17,20 +17,38 @@ class CDUAocMenu {
             ["<RETURN", "MISC>[color]inop"]
         ]);
 
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[1] = () => {
             CDUAocRequestsWeather.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[2] = () => {
             CDUAocRequestsAtis.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUAtsuMenu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[0] = () => {
             CDUAocFreeText.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[1] = () => {
             CDUAocMessagesReceived.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[2] = () => {
             CDUAocMessagesSent.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessageSentDetail.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessageSentDetail.js
@@ -52,6 +52,10 @@ class CDUAocMessageSentDetail {
             }
         };
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[5] = () => {
             CDUAocMessagesSent.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesReceived.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesReceived.js
@@ -51,10 +51,12 @@ class CDUAocMessagesReceived {
             };
         }
 
-        mcdu.onLeftInput[0] = () => {
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[0] = (value) => {
             if (messages[offset - 5]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteMessage(offset - 5);
                     CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
@@ -64,10 +66,12 @@ class CDUAocMessagesReceived {
             }
         };
 
-        mcdu.onLeftInput[1] = () => {
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[1] = (value) => {
             if (messages[offset - 4]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteMessage(offset - 4);
                     CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
@@ -77,10 +81,12 @@ class CDUAocMessagesReceived {
             }
         };
 
-        mcdu.onLeftInput[2] = () => {
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[2] = (value) => {
             if (messages[offset - 3]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteMessage(offset - 3);
                     CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
@@ -90,10 +96,12 @@ class CDUAocMessagesReceived {
             }
         };
 
-        mcdu.onLeftInput[3] = () => {
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[3] = (value) => {
             if (messages[offset - 2]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteMessage(offset - 2);
                     CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
@@ -103,10 +111,12 @@ class CDUAocMessagesReceived {
             }
         };
 
-        mcdu.onLeftInput[4] = () => {
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[4] = (value) => {
             if (messages[offset - 1]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteMessage(offset - 1);
                     CDUAocMessagesReceived.ShowPage(mcdu, messages, offset);
@@ -114,6 +124,10 @@ class CDUAocMessagesReceived {
                     CDUAocRequestsMessage.ShowPage(mcdu, messages[offset - 1]);
                 }
             }
+        };
+
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onLeftInput[5] = () => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesSent.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_MessagesSent.js
@@ -46,10 +46,12 @@ class CDUAocMessagesSent {
             };
         }
 
-        mcdu.onLeftInput[0] = () => {
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[0] = (value) => {
             if (messages[offset - 5]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteSentMessage(offset - 5);
                     CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
@@ -59,10 +61,12 @@ class CDUAocMessagesSent {
             }
         };
 
-        mcdu.onLeftInput[1] = () => {
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[1] = (value) => {
             if (messages[offset - 4]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteSentMessage(offset - 4);
                     CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
@@ -72,10 +76,12 @@ class CDUAocMessagesSent {
             }
         };
 
-        mcdu.onLeftInput[2] = () => {
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[2] = (value) => {
             if (messages[offset - 3]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteSentMessage(offset - 3);
                     CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
@@ -85,10 +91,12 @@ class CDUAocMessagesSent {
             }
         };
 
-        mcdu.onLeftInput[3] = () => {
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[3] = (value) => {
             if (messages[offset - 2]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteSentMessage(offset - 2);
                     CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
@@ -98,10 +106,12 @@ class CDUAocMessagesSent {
             }
         };
 
-        mcdu.onLeftInput[4] = () => {
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onLeftInput[4] = (value) => {
             if (messages[offset - 1]) {
-                const value = mcdu.inOut;
-                mcdu.clearUserInput();
                 if (value === FMCMainDisplay.clrValue) {
                     mcdu.deleteSentMessage(offset - 1);
                     CDUAocMessagesSent.ShowPage(mcdu, messages, offset);
@@ -109,6 +119,10 @@ class CDUAocMessagesSent {
                     CDUAocMessageSentDetail.ShowPage(mcdu, messages[offset - 1]);
                 }
             }
+        };
+
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onLeftInput[5] = () => {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsAtis.js
@@ -64,9 +64,10 @@ class CDUAocRequestsAtis {
         };
         updateView();
 
-        mcdu.onLeftInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+        mcdu.onLeftInput[0] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["arpt1"] = "";
             } else {
@@ -74,11 +75,17 @@ class CDUAocRequestsAtis {
             }
             CDUAocRequestsAtis.ShowPage(mcdu, store);
         };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[1] = () => {
             if (store.reqID != 0) {
                 store["reqID"] = 0;
             }
             CDUAocRequestsAtis.ShowPage(mcdu, store);
+        };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[2] = () => {
             if (store.reqID != 1) {
@@ -86,20 +93,32 @@ class CDUAocRequestsAtis {
             }
             CDUAocRequestsAtis.ShowPage(mcdu, store);
         };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             clearTimeout(labelTimeout);
             CDUAocMenu.ShowPage(mcdu);
         };
 
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[0] = () => {
             store["formatID"] = (store.formatID + 1) % 2;
             CDUAocRequestsAtis.ShowPage(mcdu, store);
+        };
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[1] = () => {
             if (store.reqID != 2) {
                 store["reqID"] = 2;
             }
             CDUAocRequestsAtis.ShowPage(mcdu, store);
+        };
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[5] = async () => {
             store["sendStatus"] = "QUEUED";

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsMessage.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsMessage.js
@@ -63,6 +63,9 @@ class CDUAocRequestsMessage {
             }
         };
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUAocMessagesReceived.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_AOC_RequestsWeather.js
@@ -34,9 +34,11 @@ class CDUAocRequestsWeather {
         };
         updateView();
 
-        mcdu.onRightInput[0] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onRightInput[0] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["arpt1"] = "";
             } else {
@@ -45,9 +47,11 @@ class CDUAocRequestsWeather {
             CDUAocRequestsWeather.ShowPage(mcdu, store);
         };
 
-        mcdu.onRightInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onRightInput[1] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["arpt2"] = "";
             } else {
@@ -56,9 +60,11 @@ class CDUAocRequestsWeather {
             CDUAocRequestsWeather.ShowPage(mcdu, store);
         };
 
-        mcdu.onRightInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onRightInput[2] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["arpt3"] = "";
             } else {
@@ -67,15 +73,21 @@ class CDUAocRequestsWeather {
             CDUAocRequestsWeather.ShowPage(mcdu, store);
         };
 
-        mcdu.onRightInput[3] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.rightInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
+        mcdu.onRightInput[3] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 store["arpt4"] = "";
             } else {
                 store["arpt4"] = value;
             }
             CDUAocRequestsWeather.ShowPage(mcdu, store);
+        };
+
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
 
         mcdu.onRightInput[5] = async () => {
@@ -107,9 +119,15 @@ class CDUAocRequestsWeather {
             });
         };
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             store["reqID"] = (store.reqID + 1) % 2;
             CDUAocRequestsWeather.ShowPage(mcdu, store);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             clearTimeout(labelTimeout);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_ATSU_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/ATSU/A320_Neo_CDU_ATSU_Menu.js
@@ -19,6 +19,10 @@ class CDUAtsuMenu {
         ];
         mcdu.setTemplate(display);
 
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onRightInput[1] = () => {
             CDUAocMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/A320_Neo_CDU_CFDS_Avionics_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/A320_Neo_CDU_CFDS_Avionics_Menu.js
@@ -17,6 +17,10 @@ class CDUCfdsAvionicsMenu {
             ["<RETURN[color]blue", "PRINT*[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+
         mcdu.onLeftInput[5] = () => {
             CDUCfdsMainMenu.ShowPage(mcdu);
         };
@@ -47,6 +51,10 @@ class CDUCfdsAvionicsMenu {
             [""],
             ["<RETURN[color]blue", "PRINT*[color]blue"]
         ]);
+
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
 
         mcdu.onLeftInput[5] = () => {
             CDUCfdsMainMenu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/A320_Neo_CDU_CFDS_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/A320_Neo_CDU_CFDS_Menu.js
@@ -18,8 +18,15 @@ class CDUCfdsMainMenu {
             ["*SEND[color]blue", "PRINT*[color]blue", "FLT REP"]
         ]);
 
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[3] = () => {
             CDUCfdsAvionicsMenu.ShowPage(mcdu);
+        };
+
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[4] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/A320_Neo_CDU_CFDS_Test_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/A320_Neo_CDU_CFDS_Test_Menu.js
@@ -17,32 +17,62 @@ class CDUCfdsTestMenu {
             ["<RETURN[color]blue", "NAV>"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDUCfdsTestAircond.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[2] = () => {
             CDUCfdsTestCom.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[3] = () => {
             CDUCfdsTestElec.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[4] = () => {
             CDUCfdsTestFire.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[0] = () => {
             CDUCfdsTestFctl.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[2] = () => {
             CDUCfdsTestIce.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[3] = () => {
             CDUCfdsTestInst.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[4] = () => {
             CDUCfdsTestLG.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[5] = () => {
             CDUCfdsTestNav.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsMainMenu.ShowPage(mcdu);
@@ -75,11 +105,20 @@ class CDUCfdsTestMenu {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDUCfdsTestPneu.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsMainMenu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[0] = () => {
             CDUCfdsTestEng.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/COMMON/A320_Neo_CDU_CFDS_Common_GroundScanning.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/COMMON/A320_Neo_CDU_CFDS_Common_GroundScanning.js
@@ -18,6 +18,9 @@ class CDU_CFDS_Test_Common_GroundScanning {
         ]);
 
         // IMPLEMENTED BUTTONS
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestInst.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/COMMON/A320_Neo_CDU_CFDS_Common_PowerUpTestRes.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/COMMON/A320_Neo_CDU_CFDS_Common_PowerUpTestRes.js
@@ -18,6 +18,9 @@ class CDU_CFDS_Test_Common_PowerUp {
         ]);
 
         // IMPLEMENTED BUTTONS
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestInst.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_AIRCOND/A320_Neo_CDU_CFDS_Test_Aircond.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_AIRCOND/A320_Neo_CDU_CFDS_Test_Aircond.js
@@ -17,6 +17,9 @@ class CDUCfdsTestAircond {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_COM/A320_Neo_CDU_CFDS_Test_Com.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_COM/A320_Neo_CDU_CFDS_Test_Com.js
@@ -17,6 +17,9 @@ class CDUCfdsTestCom {
             ["<RETURN[color]blue", "VHF 3>[color]inop"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };
@@ -48,6 +51,9 @@ class CDUCfdsTestCom {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_ELEC/A320_Neo_CDU_CFDS_Test_Elec.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_ELEC/A320_Neo_CDU_CFDS_Test_Elec.js
@@ -17,6 +17,9 @@ class CDUCfdsTestElec {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_ENG/A320_Neo_CDU_CFDS_Test_Eng.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_ENG/A320_Neo_CDU_CFDS_Test_Eng.js
@@ -17,6 +17,9 @@ class CDUCfdsTestEng {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage2(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_FCTL/A320_Neo_CDU_CFDS_Test_Fctl.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_FCTL/A320_Neo_CDU_CFDS_Test_Fctl.js
@@ -17,6 +17,9 @@ class CDUCfdsTestFctl {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_FIRE/A320_Neo_CDU_CFDS_Test_Fire.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_FIRE/A320_Neo_CDU_CFDS_Test_Fire.js
@@ -17,6 +17,9 @@ class CDUCfdsTestFire {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_FUEL/A320_Neo_CDU_CFDS_Test_Fuel.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_FUEL/A320_Neo_CDU_CFDS_Test_Fuel.js
@@ -18,26 +18,50 @@ class CDUCfdsTestFuel {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDU_CFDS_Test_Inst_ECAM1_Menu.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             CDU_CFDS_Test_Inst_ECAM2_Menu.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             CDU_CFDS_Test_Inst_DFDRS_Menu.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[0] = () => {
             CDU_CFDS_Test_Inst_CFDIU_Menu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[1] = () => {
             CDU_CFDS_Test_Inst_EIS1_Menu.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[2] = () => {
             CDU_CFDS_Test_Inst_EIS2_Menu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[3] = () => {
             CDU_CFDS_Test_Inst_EIS3_Menu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_ICE/A320_Neo_CDU_CFDS_Test_Ice.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_ICE/A320_Neo_CDU_CFDS_Test_Ice.js
@@ -17,6 +17,9 @@ class CDUCfdsTestIce {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INFO/A320_Neo_CDU_CFDS_Test_Info.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INFO/A320_Neo_CDU_CFDS_Test_Info.js
@@ -18,26 +18,50 @@ class CDUCfdsTestInfo {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDU_CFDS_Test_Inst_ECAM1_Menu.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             CDU_CFDS_Test_Inst_ECAM2_Menu.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             CDU_CFDS_Test_Inst_DFDRS_Menu.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[0] = () => {
             CDU_CFDS_Test_Inst_CFDIU_Menu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[1] = () => {
             CDU_CFDS_Test_Inst_EIS1_Menu.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[2] = () => {
             CDU_CFDS_Test_Inst_EIS2_Menu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[3] = () => {
             CDU_CFDS_Test_Inst_EIS3_Menu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/A320_Neo_CDU_CFDS_Test_Inst.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/A320_Neo_CDU_CFDS_Test_Inst.js
@@ -17,26 +17,50 @@ class CDUCfdsTestInst {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDU_CFDS_Test_Inst_ECAM_Menu.ShowPage(mcdu, 1);
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             CDU_CFDS_Test_Inst_ECAM_Menu.ShowPage(mcdu, 2);
         };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             CDU_CFDS_Test_Inst_DFDRS_Menu.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[0] = () => {
             CDU_CFDS_Test_Inst_CFDIU_Menu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[1] = () => {
             CDU_CFDS_Test_Inst_EIS_Menu.ShowPage(mcdu, 1);
         };
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[2] = () => {
             CDU_CFDS_Test_Inst_EIS_Menu.ShowPage(mcdu, 2);
+        };
+        mcdu.rightInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[3] = () => {
             CDU_CFDS_Test_Inst_EIS_Menu.ShowPage(mcdu, 3);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/CFDIU/A320_Neo_CDU_CFDS_Test_Inst_CFDIU_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/CFDIU/A320_Neo_CDU_CFDS_Test_Inst_CFDIU_Menu.js
@@ -17,6 +17,9 @@ class CDU_CFDS_Test_Inst_CFDIU_Menu {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestInst.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/DFDRS/A320_Neo_CDU_CFDS_Test_Inst_DFDRS_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/DFDRS/A320_Neo_CDU_CFDS_Test_Inst_DFDRS_Menu.js
@@ -17,6 +17,9 @@ class CDU_CFDS_Test_Inst_DFDRS_Menu {
             ["<RETURN[color]blue", "DATA>[color]inop"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestInst.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/ECAM/A320_Neo_CDU_CFDS_Test_Inst_ECAM_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/ECAM/A320_Neo_CDU_CFDS_Test_Inst_ECAM_Menu.js
@@ -18,6 +18,9 @@ class CDU_CFDS_Test_Inst_ECAM_Menu {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestInst.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/EIS/A320_Neo_CDU_CFDS_Test_Inst_EIS_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/EIS/A320_Neo_CDU_CFDS_Test_Inst_EIS_Menu.js
@@ -19,9 +19,15 @@ class CDU_CFDS_Test_Inst_EIS_Menu {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             SimVar.SetSimVarValue(`L:A32NX_DMC_DISPLAYTEST:${eisIndex}`, "Enum", 0);
             CDUCfdsTestInst.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[3] = () => {
             CDU_CFDS_Test_Inst_EIS_Tests.ShowPage(mcdu, eisIndex);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/EIS/A320_Neo_CDU_CFDS_Test_Inst_EIS_Tests.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/EIS/A320_Neo_CDU_CFDS_Test_Inst_EIS_Tests.js
@@ -19,8 +19,14 @@ class CDU_CFDS_Test_Inst_EIS_Tests {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             CDU_CFDS_Test_Inst_EIS_Tests_Display.ShowPage(mcdu, eisIndex);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDU_CFDS_Test_Inst_EIS_Menu.ShowPage(mcdu, eisIndex);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/EIS/A320_Neo_CDU_CFDS_Test_Inst_EIS_Tests_Display.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_INST/EIS/A320_Neo_CDU_CFDS_Test_Inst_EIS_Tests_Display.js
@@ -19,6 +19,9 @@ class CDU_CFDS_Test_Inst_EIS_Tests_Display {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDU_CFDS_Test_Inst_EIS_Tests.ShowPage(mcdu, eisIndex);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_LG/A320_Neo_CDU_CFDS_Test_LG.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_LG/A320_Neo_CDU_CFDS_Test_LG.js
@@ -17,6 +17,9 @@ class CDUCfdsTestLG {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_NAV/A320_Neo_CDU_CFDS_Test_Nav.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_NAV/A320_Neo_CDU_CFDS_Test_Nav.js
@@ -17,6 +17,9 @@ class CDUCfdsTestNav {
             ["<RETURN[color]blue", "MMR 1>[color]inop"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };
@@ -48,6 +51,9 @@ class CDUCfdsTestNav {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };
@@ -79,6 +85,9 @@ class CDUCfdsTestNav {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_PNEU/A320_Neo_CDU_CFDS_Test_Pneu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/CFDS/TEST_PNEU/A320_Neo_CDU_CFDS_Test_Pneu.js
@@ -17,6 +17,9 @@ class CDUCfdsTestPneu {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDUCfdsTestMenu.ShowPage2(mcdu);
         };

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_ADIRS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_ADIRS.js
@@ -35,11 +35,17 @@ class CDU_OPTIONS_ADIRS {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             if (storedAlignTime != "INSTANT") {
                 NXDataStore.set("CONFIG_ALIGN_TIME", "INSTANT");
                 CDU_OPTIONS_ADIRS.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             if (storedAlignTime != "FAST") {
@@ -47,11 +53,17 @@ class CDU_OPTIONS_ADIRS {
                 CDU_OPTIONS_ADIRS.ShowPage(mcdu);
             }
         };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             if (storedAlignTime != "REAL") {
                 NXDataStore.set("CONFIG_ALIGN_TIME", "REAL");
                 CDU_OPTIONS_ADIRS.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDU_OPTIONS_MainMenu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_ATIS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_ATIS.js
@@ -39,11 +39,17 @@ class CDU_OPTIONS_ATIS {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             if (storedAtisSrc != "FAA") {
                 NXDataStore.set("CONFIG_ATIS_SRC", "FAA");
                 CDU_OPTIONS_ATIS.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             if (storedAtisSrc != "VATSIM") {
@@ -51,17 +57,26 @@ class CDU_OPTIONS_ATIS {
                 CDU_OPTIONS_ATIS.ShowPage(mcdu);
             }
         };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             if (storedAtisSrc != "PILOTEDGE") {
                 NXDataStore.set("CONFIG_ATIS_SRC", "PILOTEDGE");
                 CDU_OPTIONS_ATIS.ShowPage(mcdu);
             }
         };
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[3] = () => {
             if (storedAtisSrc != "IVAO") {
                 NXDataStore.set("CONFIG_ATIS_SRC", "IVAO");
                 CDU_OPTIONS_ATIS.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDU_OPTIONS_MainMenu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_METAR.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_METAR.js
@@ -43,11 +43,17 @@ class CDU_OPTIONS_METAR {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             if (storedMetarSrc != "MSFS") {
                 NXDataStore.set("CONFIG_METAR_SRC", "MSFS");
                 CDU_OPTIONS_METAR.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             mcdu.showErrorMessage("NOT YET IMPLEMENTED");
@@ -55,11 +61,17 @@ class CDU_OPTIONS_METAR {
                 mcdu.showErrorMessage("");
             }, 1000);
         };
+        mcdu.leftInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[2] = () => {
             if (storedMetarSrc != "VATSIM") {
                 NXDataStore.set("CONFIG_METAR_SRC", "VATSIM");
                 CDU_OPTIONS_METAR.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[3] = () => {
             if (storedMetarSrc != "PILOTEDGE") {
@@ -67,11 +79,17 @@ class CDU_OPTIONS_METAR {
                 CDU_OPTIONS_METAR.ShowPage(mcdu);
             }
         };
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[4] = () => {
             if (storedMetarSrc != "IVAO") {
                 NXDataStore.set("CONFIG_METAR_SRC", "IVAO");
                 CDU_OPTIONS_METAR.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDU_OPTIONS_MainMenu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_TAF.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_AOC_TAF.js
@@ -31,17 +31,26 @@ class CDU_OPTIONS_TAF {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             if (storedTafSrc != "NOAA") {
                 NXDataStore.set("CONFIG_TAF_SRC", "NOAA");
                 CDU_OPTIONS_TAF.ShowPage(mcdu);
             }
         };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[1] = () => {
             if (storedTafSrc != "IVAO") {
                 NXDataStore.set("CONFIG_TAF_SRC", "IVAO");
                 CDU_OPTIONS_TAF.ShowPage(mcdu);
             }
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDU_OPTIONS_MainMenu.ShowPage(mcdu);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_Menu.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_Menu.js
@@ -30,28 +30,47 @@ class CDU_OPTIONS_MainMenu {
             ["<RETURN[color]blue"]
         ]);
 
+        mcdu.leftInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[0] = () => {
             CDU_OPTIONS_ATIS.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[1] = () => {
             CDU_OPTIONS_METAR.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[3] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[3] = () => {
             CDU_OPTIONS_TAF.ShowPage(mcdu);
         };
+        mcdu.leftInputDelay[4] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[4] = () => {
             CDU_OPTIONS_TELEX.ShowPage(mcdu);
+        };
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onLeftInput[5] = () => {
             CDUMenuPage.ShowPage(mcdu);
         };
 
+        mcdu.rightInputDelay[0] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onRightInput[0] = () => {
             CDU_OPTIONS_ADIRS.ShowPage(mcdu);
         };
-        mcdu.onRightInput[1] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.rightInputDelay[1] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+        mcdu.onRightInput[1] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 NXDataStore.set("CONFIG_ACCEL_ALT", "1500");
             } else if (isNaN(value) || parseInt(value) < 1000 || parseInt(value) > 5000) {
@@ -61,9 +80,10 @@ class CDU_OPTIONS_MainMenu {
             }
             CDU_OPTIONS_MainMenu.ShowPage(mcdu);
         };
-        mcdu.onRightInput[2] = () => {
-            const value = mcdu.inOut;
-            mcdu.clearUserInput();
+        mcdu.rightInputDelay[2] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
+        mcdu.onRightInput[2] = (value) => {
             if (value === FMCMainDisplay.clrValue) {
                 NXDataStore.set("CONFIG_SELF_TEST_TIME", "15");
             } else if (isNaN(value) || parseInt(value) < 5 || parseInt(value) > 40) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_TELEX.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/OPTIONS/A320_Neo_CDU_OPTIONS_TELEX.js
@@ -29,8 +29,14 @@ class CDU_OPTIONS_TELEX {
             ["<RETURN[color]blue", telexToggleText]
         ]);
 
+        mcdu.leftInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
+        };
         mcdu.onLeftInput[5] = () => {
             CDU_OPTIONS_MainMenu.ShowPage(mcdu);
+        };
+        mcdu.rightInputDelay[5] = () => {
+            return mcdu.getDelaySwitchPage();
         };
         mcdu.onRightInput[5] = () => {
             switch (storedTelexStatus) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FMC/A32NX_FMCMainDisplay.js
@@ -11,6 +11,8 @@ class FMCMainDisplay extends BaseAirliners {
         this._inOut = undefined;
         this.onLeftInput = [];
         this.onRightInput = [];
+        this.leftInputDelay = [];
+        this.rightInputDelay = [];
         this.lastPos = "";
         this.costIndex = 0;
         this.lastUserInput = "";
@@ -349,13 +351,16 @@ class FMCMainDisplay extends BaseAirliners {
     clearUserInput() {
         if (!this.isDisplayingErrorMessage) {
             this.lastUserInput = this.inOut;
+            this.inOut = "";
+            this._inOutElement.style.color = "#ffffff";
+            return this.lastUserInput;
+        } else {
+            return this.inOut;
         }
-        this.inOut = "";
-        this._inOutElement.style.color = "#ffffff";
     }
 
     showErrorMessage(message, color = "#ffffff") {
-        if (!this.isDisplayingErrorMessage) {
+        if (!this.isDisplayingErrorMessage && this.inOut) {
             this.lastUserInput = this.inOut;
         }
         this.isDisplayingErrorMessage = true;
@@ -3123,9 +3128,19 @@ class FMCMainDisplay extends BaseAirliners {
             } else if (input === "NAVRAD") {
                 this.onRad();
             } else if (input === "PREVPAGE") {
-                this.onPrevPage();
+                const cur = this.page.Current;
+                setTimeout(() => {
+                    if (this.page.Current === cur) {
+                        this.onPrevPage();
+                    }
+                }, this.getDelaySwitchPage());
             } else if (input === "NEXTPAGE") {
-                this.onNextPage();
+                const cur = this.page.Current;
+                setTimeout(() => {
+                    if (this.page.Current === cur) {
+                        this.onNextPage();
+                    }
+                }, this.getDelaySwitchPage());
             } else if (input === "SP") {
                 this.onSp();
             } else if (input === "DEL") {
@@ -3155,14 +3170,26 @@ class FMCMainDisplay extends BaseAirliners {
                 const v = parseInt(input[1]);
                 if (isFinite(v)) {
                     if (this.onLeftInput[v - 1]) {
-                        this.onLeftInput[v - 1]();
+                        const value = this.clearUserInput();
+                        const cur = this.page.Current;
+                        setTimeout(() => {
+                            if (this.page.Current === cur) {
+                                this.onLeftInput[v - 1](value);
+                            }
+                        }, this.leftInputDelay[v - 1] ? this.leftInputDelay[v - 1](value) : this.getDelayBasic());
                     }
                 }
             } else if (input.length === 2 && input[0] === "R") {
                 const v = parseInt(input[1]);
                 if (isFinite(v)) {
                     if (this.onRightInput[v - 1]) {
-                        this.onRightInput[v - 1]();
+                        const value = this.clearUserInput();
+                        const cur = this.page.Current;
+                        setTimeout(() => {
+                            if (this.page.Current === cur) {
+                                this.onRightInput[v - 1](value);
+                            }
+                        }, this.rightInputDelay[v - 1] ? this.rightInputDelay[v - 1]() : this.getDelayBasic());
                     }
                 }
             } else if (input.length === 1 && FMCMainDisplay._AvailableKeys.indexOf(input) !== -1) {
@@ -3185,6 +3212,8 @@ class FMCMainDisplay extends BaseAirliners {
         }
         this.onLeftInput = [];
         this.onRightInput = [];
+        this.leftInputDelay = [];
+        this.rightInputDelay = [];
         this.onPrevPage = undefined;
         this.onNextPage = undefined;
         this.pageUpdate = undefined;


### PR DESCRIPTION
…1834)

* fixed error message deletes input, added input delay support, updated init page A and B

* updated cdu pages

* fake error massages now proper error massages

* updated cdu/atsu

* updated cdu/options

* changed missing error message conversion

* corrected timeouts add page menu buttons delay

* added missing button overrides

* added ability to send parameter for inputDelay

* add delay for mcdu menu page

* added AIDS, ATSU and CFDS

* updated changelog

* updated changelog - changed mcdu to cdu

* added missing delay overrides to cdu/options/

* removed console calls for performance

* adjusted #1845 changes.

* added changes to #1524

* fixed errors without direct user input delete scratchpad

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created and uploaded.
The build script will have already been run with the latest changes, so no need to rerun it once you download the zip.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the right side, click on the **Artifacts** drop down and click the **A32NX** link
